### PR TITLE
Added generic for value types

### DIFF
--- a/src/components/form-context.tsx
+++ b/src/components/form-context.tsx
@@ -2,6 +2,6 @@ import { createContext } from 'react';
 import { FormApiInterface, FormState } from './form';
 import { RadioGroupApi } from './fields/radio-group';
 
-export const ContextApi = createContext<FormApiInterface | undefined>(undefined);
+export const ContextApi = createContext<FormApiInterface<any> | undefined>(undefined);
 export const ContextForm = createContext<FormState | undefined>(undefined);
 export const ContextRadioGroup = createContext<RadioGroupApi | undefined>(undefined);

--- a/src/components/form.tsx
+++ b/src/components/form.tsx
@@ -27,7 +27,7 @@ export interface ValidationRulesInterface {
 
 export type DisabledInterface = string[];
 
-export interface FormApiInterface<Values> {
+export interface FormApiInterface<Values extends ValuesType = ValuesType> {
   setTouched: (name: string, callback?: () => void) => void;
   setValue: (name: string, value: ValueType, callback?: () => void) => void;
   getValue: (name: string) => ValueType;

--- a/src/components/form.tsx
+++ b/src/components/form.tsx
@@ -27,7 +27,7 @@ export interface ValidationRulesInterface {
 
 export type DisabledInterface = string[];
 
-export interface FormApiInterface {
+export interface FormApiInterface<Values> {
   setTouched: (name: string, callback?: () => void) => void;
   setValue: (name: string, value: ValueType, callback?: () => void) => void;
   getValue: (name: string) => ValueType;
@@ -36,39 +36,42 @@ export interface FormApiInterface {
   setErrors: (name: string, value: ValidationErrorType, callback?: () => void) => void;
   getErrorClass: () => string | undefined;
   getInvalidClass: () => string | undefined;
-  getAllValues: () => ValuesType;
+  getAllValues: () => Values;
   getAllErrors: () => ValidationErrorsInterface;
   setAllErrors: (errors: ValidationErrorsInterface, callback?: () => void) => void;
-  setAllValues: (values: ValuesType, callback?: () => void) => void;
+  setAllValues: (values: Values, callback?: () => void) => void;
   getAllDisabled: () => DisabledInterface;
   setDisabled: (name: string) => void;
   removeDisabled: (name: string) => void;
   isDisabled: (name: string) => boolean;
-  getValuesDiff: (maxLevel?: number) => ValuesType;
+  getValuesDiff: (maxLevel?: number) => Partial<Values>;
   hasChanges: () => boolean;
   submit: () => void;
 }
 
-export interface FormProps {
-  children: ((api: FormApiInterface) => ReactElement) | ReactElement | ReactElement[];
-  onSubmit: (values: ValuesType, api: FormApiInterface) => void;
-  defaultValues?: ValuesType;
-  onChange?: (api: FormApiInterface) => void;
-  onTouch?: (api: FormApiInterface) => void;
-  onError?: (errors: ValidationErrorsInterface, api: FormApiInterface) => void;
-  validation?: (api: FormApiInterface) => ValidationRulesInterface;
+export interface FormProps<Values> {
+  children: ((api: FormApiInterface<Values>) => ReactElement) | ReactElement | ReactElement[];
+  onSubmit: (values: Values, api: FormApiInterface<Values>) => void;
+  defaultValues?: Values;
+  onChange?: (api: FormApiInterface<Values>) => void;
+  onTouch?: (api: FormApiInterface<Values>) => void;
+  onError?: (errors: ValidationErrorsInterface, api: FormApiInterface<Values>) => void;
+  validation?: (api: FormApiInterface<Values>) => ValidationRulesInterface;
   errorClass?: string;
   invalidClass?: string;
   [key: string]: any;
 }
 
-export interface FormState {
-  values: ValuesType;
+export interface FormState<Values extends ValuesType = ValuesType> {
+  values: Values;
   errors: ValidationErrorsInterface;
   disabled: DisabledInterface;
 }
 
-export class Form extends React.Component<FormProps, FormState> {
+export class Form<Values extends ValuesType = ValuesType> extends React.Component<
+  FormProps<Values>,
+  FormState<Values>
+> {
   static defaultProps = {
     defaultValues: {},
     onError: undefined,
@@ -126,7 +129,7 @@ export class Form extends React.Component<FormProps, FormState> {
     this.api.submit();
   };
 
-  api: FormApiInterface = {
+  api: FormApiInterface<Values> = {
     setTouched: (name: string, callback?: () => void): void => {
       const { validation, onTouch } = this.props;
       const combinedCallback = () => {
@@ -206,7 +209,7 @@ export class Form extends React.Component<FormProps, FormState> {
       const { invalidClass } = this.props;
       return invalidClass;
     },
-    getAllValues: (): ValuesType => {
+    getAllValues: (): Values => {
       const { values } = this.state;
       return values;
     },
@@ -222,7 +225,7 @@ export class Form extends React.Component<FormProps, FormState> {
         callback,
       );
     },
-    setAllValues: (values: ValuesType, callback?: () => void): void => {
+    setAllValues: (values: Values, callback?: () => void): void => {
       this.setState(
         {
           values,
@@ -253,7 +256,7 @@ export class Form extends React.Component<FormProps, FormState> {
       const { disabled } = this.state;
       return disabled.includes(name);
     },
-    getValuesDiff: (maxLevel): ValuesType => {
+    getValuesDiff: (maxLevel): Partial<Values> => {
       const { defaultValues } = this.props;
       const { values } = this.state;
       return getValuesDiff(defaultValues, values, maxLevel);

--- a/tests/Form.test.tsx
+++ b/tests/Form.test.tsx
@@ -3,7 +3,6 @@ import React, { Fragment } from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import { render, cleanup, fireEvent } from '@testing-library/react';
 import { FieldError, Form, Text, Validator } from '../src';
-import { FormApiInterface, ValuesType } from '../src/components/form';
 
 afterEach(() => {
   cleanup();
@@ -62,12 +61,15 @@ test('set default values -> change input -> submit form -> get values difference
   };
   let diffValues = null;
   let diffValuesLevel1 = null;
-  const submit = (values: ValuesType, api: FormApiInterface) => {
-    diffValues = api.getValuesDiff();
-    diffValuesLevel1 = api.getValuesDiff(1);
-  };
   const { getByTestId } = render(
-    <Form defaultValues={defaultValues} onSubmit={submit} data-testid="form">
+    <Form
+      defaultValues={defaultValues}
+      onSubmit={(_, api) => {
+        diffValues = api.getValuesDiff();
+        diffValuesLevel1 = api.getValuesDiff(1);
+      }}
+      data-testid="form"
+    >
       <Text name="id" disabled />
       <Text name="email" data-testid="email" />
       <Text name="profile.firstName" data-testid="first-name" />
@@ -102,11 +104,13 @@ test('set default values -> change input -> submit form -> get values difference
 
 test('submit form -> ensure field is disabled ', () => {
   let isInputDisabled = null;
-  const submit = (values: ValuesType, api: FormApiInterface) => {
-    isInputDisabled = api.isDisabled('profile.firstName');
-  };
   const { getByTestId } = render(
-    <Form onSubmit={submit} data-testid="form">
+    <Form
+      onSubmit={(_, api) => {
+        isInputDisabled = api.isDisabled('profile.firstName');
+      }}
+      data-testid="form"
+    >
       <Text name="profile.firstName" data-testid="input" disabled />
     </Form>,
   );


### PR DESCRIPTION
Type of form values is inferred from usage now, same as formik does.
More information about this approach is here [https://mariusschulz.com/blog/passing-generics-to-jsx-elements-in-typescript](url)